### PR TITLE
Handle dependencies externally

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,40 @@
 # Download-script-YT
+
+Utility to queue links from the clipboard and download them with yt-dlp.
+
+Before using the script make sure all required packages are installed. Run:
+
+```bash
+python check_packages.py
+```
+
+Or install them manually:
+
+```bash
+pip install yt_dlp pyperclip requests beautifulsoup4 pystray keyboard pillow pywin32
+```
+
+Install `pywin32` only on Windows.
+
+1. Run `python main_windows_strict.py` on Windows.
+2. A tray icon will appear. Use **Ctrl+B** (or your configured hotkey) to add the selected link to `download-list.txt`.
+3. Use **Ctrl+Shift+B** or the "Скачать" tray menu item to download all queued links.
+4. The tray menu also lets you open the downloads folder, view `download-list.txt`, or change the hotkey.
+5. Choose "Выход" in the tray menu to quit.
+
+### Building an executable
+
+Use PyInstaller to bundle the script. Include the tray icon file and the
+pystray Windows backend:
+
+```bash
+pyinstaller --onefile --windowed --icon=ico.ico \
+    --add-data "ico.ico;." --hidden-import pystray._win32 \
+    main_windows_strict.py
+```
+
+Ensure all dependencies are installed **before** building. Either run
+`python check_packages.py` or install them manually as shown above.
+
+Error messages are written to `script.log` in the script folder.
+

--- a/check_packages.py
+++ b/check_packages.py
@@ -1,0 +1,37 @@
+import sys
+import subprocess
+import importlib.util
+
+required_packages = {
+    'yt_dlp': 'yt_dlp',
+    'pyperclip': 'pyperclip',
+    'requests': 'requests',
+    'bs4': 'beautifulsoup4',
+    'pystray': 'pystray',
+    'keyboard': 'keyboard',
+    'PIL': 'pillow',
+    'win32api': 'pywin32',
+}
+
+installed_new = False
+
+for module, package in required_packages.items():
+    if package == 'pywin32' and not sys.platform.startswith('win'):
+        continue
+    if importlib.util.find_spec(module) is None:
+        print(f"Installing {package}...")
+        subprocess.check_call([
+            sys.executable,
+            '-m',
+            'pip',
+            'install',
+            '--quiet',
+            '--disable-pip-version-check',
+            package,
+        ])
+        installed_new = True
+
+if installed_new:
+    print("All packages installed.")
+else:
+    print("All packages already present.")

--- a/main_windows_strict.py
+++ b/main_windows_strict.py
@@ -1,44 +1,107 @@
 import os
 import sys
-import subprocess
-import pyperclip
+import atexit
+import time
+import json
+import logging
 from urllib.parse import urlparse
-
-# === Проверка и установка необходимых пакетов ===
-required_packages = ['yt_dlp', 'pyperclip', 'requests', 'beautifulsoup4']
-for package in required_packages:
-    try:
-        __import__(package if package != 'beautifulsoup4' else 'bs4')
-    except ImportError:
-        print(f"⏳ Устанавливается пакет: {package}")
-        subprocess.check_call([sys.executable, '-m', 'pip', 'install', package])
+from typing import Optional
 
 import yt_dlp
 import requests
 from bs4 import BeautifulSoup
+import keyboard
+import pystray
+import pyperclip
 
-# === Путь к папке Downloads в текущей директории ===
-def get_base_folder():
+from PIL import Image
+import subprocess
+
+
+def get_base_folder() -> str:
+    """Returns the folder where persistent files should be stored."""
     if getattr(sys, 'frozen', False):
         return os.path.dirname(sys.executable)
     return os.path.dirname(os.path.abspath(__file__))
 
-def get_video_url():
-    url = pyperclip.paste().strip()
-    if url.startswith('http'):
-        print(f"Ссылка взята из буфера: {url}")
-        return url
-    else:
+
+def resource_path(name: str) -> str:
+    """Resolve resource path for bundled executables."""
+    if getattr(sys, 'frozen', False):
+        return os.path.join(sys._MEIPASS, name)  # type: ignore[attr-defined]
+    return os.path.join(get_base_folder(), name)
+
+
+# === Пути и файлы ===
+BASE_FOLDER = get_base_folder()
+DOWNLOADS_FOLDER = os.path.join(BASE_FOLDER, 'Downloads')
+VIDEOS_FOLDER = os.path.join(DOWNLOADS_FOLDER, 'Videos')
+PLAYLIST_FOLDER = os.path.join(VIDEOS_FOLDER, 'Playlist Videos')
+PICTURES_FOLDER = os.path.join(DOWNLOADS_FOLDER, 'Pictures')
+DOWNLOAD_LIST = os.path.join(BASE_FOLDER, 'download-list.txt')
+CONFIG_FILE = os.path.join(BASE_FOLDER, 'config.json')
+LOG_FILE = os.path.join(BASE_FOLDER, 'script.log')
+
+os.makedirs(VIDEOS_FOLDER, exist_ok=True)
+os.makedirs(PLAYLIST_FOLDER, exist_ok=True)
+os.makedirs(PICTURES_FOLDER, exist_ok=True)
+
+logging.basicConfig(
+    filename=LOG_FILE,
+    level=logging.INFO,
+    format='%(asctime)s - %(levelname)s - %(message)s',
+)
+
+
+DEFAULT_CONFIG = {
+    'add_hotkey': 'ctrl+b',
+    'download_hotkey': 'ctrl+shift+b',
+}
+
+
+def load_config() -> dict:
+    if os.path.exists(CONFIG_FILE):
         try:
-            url = input("В буфере нет корректной ссылки. Введите URL:\n").strip()
-            if url.startswith('http'):
-                return url
-            else:
-                print("Некорректный URL. Завершаем.")
-                sys.exit(1)
-        except Exception:
-            print("Ошибка при вводе. Завершаем.")
-            sys.exit(1)
+            with open(CONFIG_FILE, 'r', encoding='utf-8') as f:
+                data = json.load(f)
+                return {**DEFAULT_CONFIG, **data}
+        except Exception as e:
+            logging.error('Ошибка загрузки конфигурации: %s', e)
+    return DEFAULT_CONFIG.copy()
+
+
+def save_config(cfg: dict) -> None:
+    try:
+        with open(CONFIG_FILE, 'w', encoding='utf-8') as f:
+            json.dump(cfg, f, ensure_ascii=False, indent=2)
+    except Exception as e:
+        logging.error('Ошибка сохранения конфигурации: %s', e)
+
+
+def ensure_single_instance() -> None:
+    """Предотвращает запуск нескольких экземпляров скрипта."""
+    if sys.platform.startswith('win'):
+        import msvcrt
+        lock_path = os.path.join(BASE_FOLDER, 'script.lock')
+        lock_file = open(lock_path, 'w')
+        try:
+            msvcrt.locking(lock_file.fileno(), msvcrt.LK_NBLCK, 1)
+        except OSError:
+            logging.info('Попытка запуска второго экземпляра.')
+            print('Скрипт уже запущен.')
+            sys.exit(0)
+
+        def release_lock() -> None:
+            try:
+                msvcrt.locking(lock_file.fileno(), msvcrt.LK_UNLCK, 1)
+                lock_file.close()
+                os.remove(lock_path)
+            except Exception:
+                pass
+            logging.info('Lock file released.')
+
+        atexit.register(release_lock)
+
 
 def download_video(url, folder):
     ydl_opts = {
@@ -52,6 +115,7 @@ def download_video(url, folder):
         with yt_dlp.YoutubeDL(ydl_opts) as ydl:
             ydl.download([url])
     except Exception as e:
+        logging.error('Ошибка при скачивании YouTube-содержимого: %s', e)
         print(f"Ошибка при скачивании YouTube-содержимого: {e}")
 
 def download_playlist(url, folder):
@@ -67,6 +131,7 @@ def download_playlist(url, folder):
         with yt_dlp.YoutubeDL(ydl_opts) as ydl:
             ydl.download([url])
     except Exception as e:
+        logging.error('Ошибка при скачивании плейлиста: %s', e)
         print(f"Ошибка при скачивании плейлиста: {e}")
 
 def download_pinterest_image(url, folder):
@@ -85,44 +150,154 @@ def download_pinterest_image(url, folder):
         else:
             print("Не удалось найти изображение на странице Pinterest.")
     except Exception as e:
+        logging.error('Ошибка при скачивании изображения с Pinterest: %s', e)
         print(f"Ошибка при скачивании изображения с Pinterest: {e}")
 
-def main():
-    base_folder = get_base_folder()
-    downloads_folder = os.path.join(base_folder, 'Downloads')
-    videos_folder = os.path.join(downloads_folder, 'Videos')
-    playlist_folder = os.path.join(videos_folder, 'Playlist Videos')
-    pictures_folder = os.path.join(downloads_folder, 'Pictures')
 
-    os.makedirs(videos_folder, exist_ok=True)
-    os.makedirs(playlist_folder, exist_ok=True)
-    os.makedirs(pictures_folder, exist_ok=True)
-
-    url = get_video_url()
+def handle_url(url: str) -> None:
+    """Определяет тип ссылки и запускает скачивание."""
     hostname = urlparse(url).hostname or ""
     hostname = hostname.lower()
 
     if "youtube.com/playlist" in url:
-        print(f"Это плейлист YouTube. Скачиваем всё в: {playlist_folder}")
-        download_playlist(url, playlist_folder)
+        logging.info('Скачиваем плейлист: %s', url)
+        print(f"Это плейлист YouTube. Скачиваем всё в: {PLAYLIST_FOLDER}")
+        download_playlist(url, PLAYLIST_FOLDER)
 
     elif "youtube.com" in hostname or "youtu.be" in hostname:
-        print(f"Это видео YouTube. Скачиваем в: {videos_folder}")
-        download_video(url, videos_folder)
+        logging.info('Скачиваем видео: %s', url)
+        print(f"Это видео YouTube. Скачиваем в: {VIDEOS_FOLDER}")
+        download_video(url, VIDEOS_FOLDER)
 
     elif "pinterest.com" in hostname:
-        print(f"Это Pinterest ссылка. Пытаемся скачать...")
-        download_pinterest_image(url, pictures_folder)
+        logging.info('Скачиваем изображение Pinterest: %s', url)
+        print("Это Pinterest ссылка. Пытаемся скачать...")
+        download_pinterest_image(url, PICTURES_FOLDER)
 
     else:
+        logging.warning('Неизвестная ссылка: %s', url)
         print("Сайт не поддерживается этим скриптом.")
 
-    print("Скачивание завершено!")
 
-    try:
-        input("⚠️ Нажмите Enter, чтобы закрыть окно...")
-    except:
-        pass
+def download_all(icon: Optional[pystray.Icon] = None) -> None:
+    """Скачивает все ссылки из файла download-list.txt."""
+    if not os.path.exists(DOWNLOAD_LIST):
+        print("Файл download-list.txt не найден.")
+        return
+
+    with open(DOWNLOAD_LIST, 'r', encoding='utf-8') as f:
+        urls = [line.strip() for line in f if line.strip()]
+
+    if not urls:
+        print("Список ссылок пуст.")
+        return
+
+    for url in urls:
+        handle_url(url)
+
+    open(DOWNLOAD_LIST, 'w', encoding='utf-8').close()
+    print("Скачивание завершено!")
+    if icon is not None:
+        try:
+            icon.notify('Complete', 'Скачивание завершено')
+        except Exception:
+            pass
+
+
+def add_link_from_clipboard() -> None:
+    """Копирует выделенный текст и сохраняет как ссылку."""
+    keyboard.press_and_release('ctrl+c')
+    time.sleep(0.1)
+    url = pyperclip.paste().strip()
+    if not url:
+        print("Буфер обмена пуст.")
+        return
+
+    existing = []
+    if os.path.exists(DOWNLOAD_LIST):
+        with open(DOWNLOAD_LIST, 'r', encoding='utf-8') as f:
+            existing = [line.strip() for line in f if line.strip()]
+
+    if url in existing:
+        logging.info('Дубликат ссылки: %s', url)
+        print('Ссылка уже присутствует в списке.')
+        return
+
+    with open(DOWNLOAD_LIST, 'a', encoding='utf-8') as f:
+        f.write(url + '\n')
+    print(f"Добавлено в список: {url}")
+
+def main() -> None:
+    """Запускает горячие клавиши и значок в трее."""
+
+    ensure_single_instance()
+
+    config = load_config()
+
+    add_hotkey = config.get('add_hotkey', DEFAULT_CONFIG['add_hotkey'])
+    download_hotkey = config.get('download_hotkey', DEFAULT_CONFIG['download_hotkey'])
+
+    def change_hotkey(icon, item):
+        icon.notify('Настройка', 'Нажмите новое сочетание и Enter')
+        keyboard.unhook_all_hotkeys()
+        try:
+            new_key = keyboard.read_hotkey()
+            if new_key:
+                config['add_hotkey'] = new_key
+                save_config(config)
+                icon.notify('Готово', f'Новая клавиша: {new_key}')
+        except Exception as e:
+            logging.error('Ошибка смены горячей клавиши: %s', e)
+        finally:
+            keyboard.add_hotkey(config['add_hotkey'], add_link_from_clipboard)
+            keyboard.add_hotkey(config['download_hotkey'], lambda: download_all(tray_icon))
+
+    def on_download(icon, item):
+        download_all(icon)
+
+    def on_exit(icon, item):
+        icon.stop()
+
+    def open_list(icon, item):
+        try:
+            if sys.platform.startswith('win'):
+                os.startfile(DOWNLOAD_LIST)
+            else:
+                subprocess.Popen(['xdg-open', DOWNLOAD_LIST])
+        except Exception as e:
+            logging.error('Не удалось открыть файл со списком: %s', e)
+
+    def open_folder(icon, item):
+        try:
+            if sys.platform.startswith('win'):
+                os.startfile(DOWNLOADS_FOLDER)
+            else:
+                subprocess.Popen(['xdg-open', DOWNLOADS_FOLDER])
+        except Exception as e:
+            logging.error('Не удалось открыть папку загрузок: %s', e)
+
+    icon_path = resource_path('ico.ico')
+    image = Image.open(icon_path) if os.path.exists(icon_path) else None
+    menu = pystray.Menu(
+        pystray.MenuItem('Скачать', on_download),
+        pystray.MenuItem('Список загрузок', open_list),
+        pystray.MenuItem('Открыть папку для загрузки', open_folder),
+        pystray.MenuItem('Горячие клавиши', change_hotkey),
+        pystray.MenuItem('Выход', on_exit),
+    )
+    tray_icon = pystray.Icon('YTDownloader', image, 'YT Downloader', menu)
+
+    keyboard.add_hotkey(add_hotkey, add_link_from_clipboard)
+    keyboard.add_hotkey(download_hotkey, lambda: download_all(tray_icon))
+
+    print(f"Значок размещён в трее. Горячие клавиши {add_hotkey} и {download_hotkey} активны.")
+
+    tray_icon.run()
+
+    keyboard.unhook_all_hotkeys()
+
+    print('Скрипт завершён.')
 
 if __name__ == '__main__':
     main()
+


### PR DESCRIPTION
## Summary
- remove package installation from the main script
- add `check_packages.py` to verify and install dependencies
- store queued URLs in `download-list.txt`
- add a log file and prevent duplicate links
- add configurable hotkeys and more tray options
- document setup and new tray menu options

## Testing
- `python -m py_compile main_windows_strict.py check_packages.py`
- `python check_packages.py`
- `python main_windows_strict.py` *(fails: `Xlib.error.DisplayNameError` because the environment lacks a GUI)*

------
https://chatgpt.com/codex/tasks/task_e_687454d216608333a1e14bfb803652e4